### PR TITLE
Add dark mode toggle to UI

### DIFF
--- a/ui/app/src/App.scss
+++ b/ui/app/src/App.scss
@@ -7,18 +7,35 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+body.dark-mode {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
 h1 {
   margin-top: 0;
   font-weight: normal;
+}
+
+h1.dark-mode {
+  color: #e0e0e0;
 }
 
 h2 {
   font-weight: normal;
 }
 
+h2.dark-mode {
+  color: #e0e0e0;
+}
+
 code {
   font-family:
     source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+
+code.dark-mode {
+  color: #e0e0e0;
 }
 
 .tre-logout-message {
@@ -29,6 +46,10 @@ code {
 .tre-top-nav {
   box-shadow: 0 1px 2px 0px #033d68;
   z-index: 100;
+}
+
+.tre-top-nav.dark-mode {
+  box-shadow: 0 1px 2px 0px #1e1e1e;
 }
 
 .ms-CommandBar {
@@ -93,6 +114,10 @@ ul.tre-notifications-steps-list li {
   font-size: 1.2rem;
 }
 
+.tre-home-link.dark-mode {
+  color: #e0e0e0;
+}
+
 .tre-user-menu {
   margin-top: 2px;
 
@@ -107,6 +132,14 @@ ul.tre-notifications-steps-list li {
   .ms-Icon {
     margin-top: 3px;
   }
+}
+
+.tre-user-menu.dark-mode .ms-Persona-primaryText:hover {
+  color: #e0e0e0;
+}
+
+.tre-user-menu.dark-mode .ms-Persona-primaryText {
+  color: #e0e0e0;
 }
 
 .tre-table {
@@ -145,11 +178,19 @@ ul.tre-notifications-steps-list li {
   z-index: 100;
 }
 
+.tre-left-nav.dark-mode {
+  box-shadow: 1px 0 8px 0px #1e1e1e;
+}
+
 .tre-body-content {
   width: calc(100% - 200px);
   overflow-y: scroll;
   background-color: #faf9f8;
   padding-bottom: 80px;
+}
+
+.tre-body-content.dark-mode {
+  background-color: #121212;
 }
 
 .tre-workspace-header h1 {
@@ -165,11 +206,21 @@ ul.tre-notifications-steps-list li {
   padding: 10px;
 }
 
+.tre-panel.dark-mode {
+  background-color: #1e1e1e;
+  color: #e0e0e0;
+}
+
 .tre-resource-panel {
   box-shadow: 1px 0px 5px 0px #ccc;
   margin: 10px 15px 10px 10px;
   padding: 10px;
   background-color: #fff;
+}
+
+.tre-resource-panel.dark-mode {
+  background-color: #1e1e1e;
+  color: #e0e0e0;
 }
 
 .ms-Pivot {
@@ -180,6 +231,10 @@ input[readonly] {
   background-color: #efefef;
 }
 
+input[readonly].dark-mode {
+  background-color: #2e2e2e;
+}
+
 .tre-badge {
   border-radius: 4px;
   background-color: #efefef;
@@ -188,10 +243,16 @@ input[readonly] {
   display: inline-block;
   font-size: 12px;
 }
+
+.tre-badge.dark-mode {
+  background-color: #2e2e2e;
+}
+
 .tre-badge-in-progress {
   background-color: #ce7b00;
   color: #fff;
 }
+
 .tre-badge-failed {
   background-color: #990000;
   color: #fff;
@@ -199,22 +260,31 @@ input[readonly] {
   padding-left: 7px;
   font-size: 16px;
 }
+
 .tre-badge-success {
   background-color: #006600;
   color: #fff;
 }
+
 .tre-complex-list {
   list-style: none;
   padding: 0 0 0 20px;
   margin: 0;
 }
+
 .tre-complex-list-border {
   border-bottom: 1px #ccc solid;
   margin-left: -15px;
 }
+
+.tre-complex-list-border.dark-mode {
+  border-bottom: 1px #2e2e2e solid;
+}
+
 .tre-complex-list-string {
   padding-left: 20px;
 }
+
 .tre-complex-list .ms-Icon {
   font-size: 12px !important;
   font-weight: bold;
@@ -243,6 +313,10 @@ input[readonly] {
   }
 }
 
+.tre-power-badge.dark-mode {
+  color: #e0e0e0;
+}
+
 /* hide fields explicitly */
 .tre-hidden {
   display: none;
@@ -256,6 +330,11 @@ input[readonly] {
   padding-bottom: 10px;
 }
 
+.ms-Panel-commands.dark-mode {
+  background: #1e1e1e;
+  border-bottom: 1px #2e2e2e solid;
+}
+
 /* template description at top of panel */
 .rjsf > .ms-Grid-col {
   margin-top: -25px;
@@ -267,6 +346,10 @@ input[readonly] {
   padding: 10px;
   margin-bottom: 15px;
   font-style: normal;
+}
+
+.rjsf > .ms-Grid-col > span:first-of-type.dark-mode {
+  background-color: #2e2e2e;
 }
 
 /* border around sub-blocks */
@@ -287,7 +370,6 @@ input[readonly] {
   background-color: #fcfcfc;
 }
 
-/* sub titles and sub-sub titles */
 .ms-Panel-content
   .rjsf
   > .ms-Grid-col

--- a/ui/app/src/App.tsx
+++ b/ui/app/src/App.tsx
@@ -27,6 +27,8 @@ import { initializeFileTypeIcons } from "@fluentui/react-file-type-icons";
 import { CostResource } from "./models/costs";
 import { CostsContext } from "./contexts/CostsContext";
 import { LoadingState } from "./models/loadingState";
+import DarkModeToggle from "react-dark-mode-toggle";
+import { ThemeProvider, createTheme } from "@fluentui/react";
 
 export const App: React.FunctionComponent = () => {
   const [appRoles, setAppRoles] = useState([] as Array<string>);
@@ -43,6 +45,9 @@ export const App: React.FunctionComponent = () => {
   const [createFormResource, setCreateFormResource] = useState({
     resourceType: ResourceType.Workspace,
   } as CreateFormResource);
+  const [isDarkMode, setIsDarkMode] = useState(
+    () => localStorage.getItem("darkMode") === "true"
+  );
 
   const apiCall = useAuthApiCall();
 
@@ -65,6 +70,64 @@ export const App: React.FunctionComponent = () => {
   }, [apiCall]);
 
   useEffect(() => initializeFileTypeIcons(), []);
+
+  useEffect(() => {
+    localStorage.setItem("darkMode", isDarkMode.toString());
+  }, [isDarkMode]);
+
+  const lightTheme = createTheme({
+    palette: {
+      themePrimary: DefaultPalette.themePrimary,
+      themeLighterAlt: DefaultPalette.themeLighterAlt,
+      themeLighter: DefaultPalette.themeLighter,
+      themeLight: DefaultPalette.themeLight,
+      themeTertiary: DefaultPalette.themeTertiary,
+      themeSecondary: DefaultPalette.themeSecondary,
+      themeDarkAlt: DefaultPalette.themeDarkAlt,
+      themeDark: DefaultPalette.themeDark,
+      themeDarker: DefaultPalette.themeDarker,
+      neutralLighterAlt: DefaultPalette.neutralLighterAlt,
+      neutralLighter: DefaultPalette.neutralLighter,
+      neutralLight: DefaultPalette.neutralLight,
+      neutralQuaternaryAlt: DefaultPalette.neutralQuaternaryAlt,
+      neutralQuaternary: DefaultPalette.neutralQuaternary,
+      neutralTertiaryAlt: DefaultPalette.neutralTertiaryAlt,
+      neutralTertiary: DefaultPalette.neutralTertiary,
+      neutralSecondary: DefaultPalette.neutralSecondary,
+      neutralPrimaryAlt: DefaultPalette.neutralPrimaryAlt,
+      neutralPrimary: DefaultPalette.neutralPrimary,
+      neutralDark: DefaultPalette.neutralDark,
+      black: DefaultPalette.black,
+      white: DefaultPalette.white,
+    },
+  });
+
+  const darkTheme = createTheme({
+    palette: {
+      themePrimary: "#0078d4",
+      themeLighterAlt: "#00060a",
+      themeLighter: "#001828",
+      themeLight: "#002d4a",
+      themeTertiary: "#005a95",
+      themeSecondary: "#0083d8",
+      themeDarkAlt: "#1890f1",
+      themeDark: "#3aa0f2",
+      themeDarker: "#6abef5",
+      neutralLighterAlt: "#2a2a2a",
+      neutralLighter: "#333333",
+      neutralLight: "#414141",
+      neutralQuaternaryAlt: "#4a4a4a",
+      neutralQuaternary: "#515151",
+      neutralTertiaryAlt: "#6f6f6f",
+      neutralTertiary: "#c8c8c8",
+      neutralSecondary: "#d0d0d0",
+      neutralPrimaryAlt: "#dadada",
+      neutralPrimary: "#ffffff",
+      neutralDark: "#f4f4f4",
+      black: "#f8f8f8",
+      white: "#1b1b1b",
+    },
+  });
 
   return (
     <>
@@ -104,59 +167,68 @@ export const App: React.FunctionComponent = () => {
                     }
                     updateResource={createFormResource.updateResource}
                   />
-                  <Stack styles={stackStyles} className="tre-root">
-                    <Stack.Item grow className="tre-top-nav">
-                      <TopNav />
-                    </Stack.Item>
-                    <Stack.Item grow={100} className="tre-body">
-                      <GenericErrorBoundary>
-                        <CostsContext.Provider
-                          value={{
-                            loadingState: costsLoadingState,
-                            costs: costs,
-                            setCosts: (costs: Array<CostResource>) => {
-                              setCosts(costs);
-                            },
-                            setLoadingState: (loadingState: LoadingState) => {
-                              setCostsLoadingState(loadingState);
-                            },
-                          }}
-                        >
-                          <Routes>
-                            <Route path="*" element={<RootLayout />} />
-                            <Route
-                              path="/workspaces/:workspaceId//*"
-                              element={
-                                <WorkspaceContext.Provider
-                                  value={{
-                                    roles: workspaceRoles,
-                                    setRoles: (roles: Array<string>) => {
-                                      setWorkspaceRoles(roles);
-                                    },
-                                    costs: workspaceCosts,
-                                    setCosts: (costs: Array<CostResource>) => {
-                                      setWorkspaceCosts(costs);
-                                    },
-                                    workspace: selectedWorkspace,
-                                    setWorkspace: (w: Workspace) => {
-                                      setSelectedWorkspace(w);
-                                    },
-                                    workspaceApplicationIdURI:
-                                      selectedWorkspace.properties?.scope_id,
-                                  }}
-                                >
-                                  <WorkspaceProvider />
-                                </WorkspaceContext.Provider>
-                              }
-                            />
-                          </Routes>
-                        </CostsContext.Provider>
-                      </GenericErrorBoundary>
-                    </Stack.Item>
-                    <Stack.Item grow>
-                      <Footer />
-                    </Stack.Item>
-                  </Stack>
+                  <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
+                    <Stack styles={stackStyles} className="tre-root">
+                      <Stack.Item grow className="tre-top-nav">
+                        <TopNav />
+                        <DarkModeToggle
+                          onChange={setIsDarkMode}
+                          checked={isDarkMode}
+                          size={60}
+                        />
+                      </Stack.Item>
+                      <Stack.Item grow={100} className="tre-body">
+                        <GenericErrorBoundary>
+                          <CostsContext.Provider
+                            value={{
+                              loadingState: costsLoadingState,
+                              costs: costs,
+                              setCosts: (costs: Array<CostResource>) => {
+                                setCosts(costs);
+                              },
+                              setLoadingState: (loadingState: LoadingState) => {
+                                setCostsLoadingState(loadingState);
+                              },
+                            }}
+                          >
+                            <Routes>
+                              <Route path="*" element={<RootLayout />} />
+                              <Route
+                                path="/workspaces/:workspaceId//*"
+                                element={
+                                  <WorkspaceContext.Provider
+                                    value={{
+                                      roles: workspaceRoles,
+                                      setRoles: (roles: Array<string>) => {
+                                        setWorkspaceRoles(roles);
+                                      },
+                                      costs: workspaceCosts,
+                                      setCosts: (
+                                        costs: Array<CostResource>,
+                                      ) => {
+                                        setWorkspaceCosts(costs);
+                                      },
+                                      workspace: selectedWorkspace,
+                                      setWorkspace: (w: Workspace) => {
+                                        setSelectedWorkspace(w);
+                                      },
+                                      workspaceApplicationIdURI:
+                                        selectedWorkspace.properties?.scope_id,
+                                    }}
+                                  >
+                                    <WorkspaceProvider />
+                                  </WorkspaceContext.Provider>
+                                }
+                              />
+                            </Routes>
+                          </CostsContext.Provider>
+                        </GenericErrorBoundary>
+                      </Stack.Item>
+                      <Stack.Item grow>
+                        <Footer />
+                      </Stack.Item>
+                    </Stack>
+                  </ThemeProvider>
                 </CreateUpdateResourceContext.Provider>
               </AppRolesContext.Provider>
             </MsalAuthenticationTemplate>

--- a/ui/app/src/components/shared/TopNav.tsx
+++ b/ui/app/src/components/shared/TopNav.tsx
@@ -3,11 +3,20 @@ import { getTheme, Icon, mergeStyles, Stack } from "@fluentui/react";
 import { Link } from "react-router-dom";
 import { UserMenu } from "./UserMenu";
 import { NotificationPanel } from "./notifications/NotificationPanel";
+import DarkModeToggle from "react-dark-mode-toggle";
 
 export const TopNav: React.FunctionComponent = () => {
+  const [isDarkMode, setIsDarkMode] = React.useState(
+    () => localStorage.getItem("darkMode") === "true"
+  );
+
+  React.useEffect(() => {
+    localStorage.setItem("darkMode", isDarkMode.toString());
+  }, [isDarkMode]);
+
   return (
     <>
-      <div className={contentClass}>
+      <div className={`${contentClass} ${isDarkMode ? "dark-mode" : ""}`}>
         <Stack horizontal>
           <Stack.Item grow={100}>
             <Link to="/" className="tre-home-link">
@@ -24,6 +33,13 @@ export const TopNav: React.FunctionComponent = () => {
           </Stack.Item>
           <Stack.Item>
             <NotificationPanel />
+          </Stack.Item>
+          <Stack.Item>
+            <DarkModeToggle
+              onChange={setIsDarkMode}
+              checked={isDarkMode}
+              size={60}
+            />
           </Stack.Item>
           <Stack.Item grow>
             <UserMenu />


### PR DESCRIPTION
Add dark mode functionality to the UI.

* **App.scss**: Add dark mode styles for body, h1, h2, code, and other classes.
* **App.tsx**: Import `react-dark-mode-toggle` and add logic for toggling between light and dark modes. Implement local storage to save user preference for dark mode. Update the theme context to switch between light and dark themes based on the current mode.
* **TopNav.tsx**: Add a dark mode toggle button. Update styles to support dark mode.

